### PR TITLE
Add browserify support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,5 @@
+
+module.exports = {
+  protocol: require('./lib/protocol')
+};
+

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "engines": {
     "node": ">=0.8.16"
   },
+  "browser": "browser.js",
   "devDependencies": {
     "mocha": "~1.8.2",
     "mkdirp": "~0.3.4",


### PR DESCRIPTION
I wanted to use node-minecraft-protocol in the web browser via [browserify](http://browserify.org/), but it fails because of the ursa native library dependency:

    Error: module "../bin/ursaNative" not found from "node-minecraft-protocol/node_modules/ursa/lib/ursa.js"

So I added a browser-specific module entry point, which does not include any ursa-dependent functionality. This means auth/crypto/etc is unavailable in this environment, but you can still encode and decode packets.

(@roblabla has been working on replacing [ursa](https://github.com/Obvious/ursa) with [Forge](https://github.com/digitalbazaar/forge), pure JavaScript: https://github.com/roblabla/node-minecraft-protocol/tree/feature-purejsrsa-forge - which could also solve this unbrowserifyable natives problem. But at least for my purposes, only including lib/protocol when browserified was sufficient. Didn't need any of the decryption functionality.)